### PR TITLE
Route chatbot through API gateway

### DIFF
--- a/Backend/api_gateway/package.json
+++ b/Backend/api_gateway/package.json
@@ -24,6 +24,7 @@
     "@nestjs/core": "^11.0.1",
     "@nestjs/microservices": "^11.0.14",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/axios": "^11.0.1",
     "axios": "^1.8.4",
     "class-validator": "^0.14.1",
     "reflect-metadata": "^0.2.2",

--- a/Backend/api_gateway/src/app.module.ts
+++ b/Backend/api_gateway/src/app.module.ts
@@ -6,6 +6,7 @@ import { GlobalModule } from './global/global.module';
 import { EventsModule } from './events/events.module';
 import { DevisModule } from './documents/devis/devis.module';
 import { DocumentsModule } from './documents/documents.module';
+import { ChatbotModule } from './chatbot/chatbot.module';
 
 @Module({
   imports: [
@@ -16,6 +17,7 @@ import { DocumentsModule } from './documents/documents.module';
     DocumentsModule,
     DevisModule,
     EventsModule,
+    ChatbotModule,
   ],
   controllers: [],
   providers: [],

--- a/Backend/api_gateway/src/chatbot/analyze.controller.ts
+++ b/Backend/api_gateway/src/chatbot/analyze.controller.ts
@@ -1,0 +1,40 @@
+import { Controller, Post, Body } from '@nestjs/common';
+import { HttpService } from '@nestjs/axios';
+import { firstValueFrom } from 'rxjs';
+
+@Controller('analyze')
+export class AnalyzeController {
+  constructor(private readonly httpService: HttpService) {}
+
+  @Post('chatbot')
+  async analyzeChatbot(@Body() payload: any) {
+    const { data } = await firstValueFrom(
+      this.httpService.post('/analyze/chatbot', payload),
+    );
+    return data;
+  }
+
+  @Post('conversation')
+  async analyzeConversation(@Body() payload: any) {
+    const { data } = await firstValueFrom(
+      this.httpService.post('/analyze/conversation', payload),
+    );
+    return data;
+  }
+
+  @Post('question')
+  async analyzeQuestion(@Body() payload: any) {
+    const { data } = await firstValueFrom(
+      this.httpService.post('/analyze/question', payload),
+    );
+    return data;
+  }
+
+  @Post('execute-query')
+  async executeQuery(@Body() payload: any) {
+    const { data } = await firstValueFrom(
+      this.httpService.post('/analyze/execute-query', payload),
+    );
+    return data;
+  }
+}

--- a/Backend/api_gateway/src/chatbot/chatbot.controller.ts
+++ b/Backend/api_gateway/src/chatbot/chatbot.controller.ts
@@ -1,0 +1,16 @@
+import { Controller, Get } from '@nestjs/common';
+import { HttpService } from '@nestjs/axios';
+import { firstValueFrom } from 'rxjs';
+
+@Controller('chatbot')
+export class ChatbotController {
+  constructor(private readonly httpService: HttpService) {}
+
+  @Get('health')
+  async getHealth() {
+    const { data } = await firstValueFrom(
+      this.httpService.get('/chatbot/health'),
+    );
+    return data;
+  }
+}

--- a/Backend/api_gateway/src/chatbot/chatbot.module.ts
+++ b/Backend/api_gateway/src/chatbot/chatbot.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { HttpModule } from '@nestjs/axios';
+import { ChatbotController } from './chatbot.controller';
+import { AnalyzeController } from './analyze.controller';
+
+@Module({
+  imports: [
+    HttpModule.register({
+      baseURL: 'http://chatbot:5599',
+    }),
+  ],
+  controllers: [ChatbotController, AnalyzeController],
+})
+export class ChatbotModule {}

--- a/Backend/chatbot_service/src/elasticsearch/utils/query-indexer.util.ts
+++ b/Backend/chatbot_service/src/elasticsearch/utils/query-indexer.util.ts
@@ -113,12 +113,12 @@ export async function checkAndIndexQueries(
 /**
  * Fonction utilitaire pour indexer rapidement une ou plusieurs requêtes de n'importe quel module
  * @param queries Objet contenant les requêtes à indexer
- * @param apiBaseUrl URL de base de l'API (par défaut: http://localhost:5599)
+ * @param apiBaseUrl URL de base de l'API (par défaut: http://localhost:3000)
  * @returns Promesse résolue avec le résultat de l'indexation
  */
 export async function indexQueries(
     queries: Record<string, any>,
-    apiBaseUrl: string = 'http://localhost:5599'
+    apiBaseUrl: string = 'http://localhost:3000'
   ): Promise<any> {
     try {
       // Préparation des données pour l'API
@@ -153,13 +153,13 @@ export async function indexQueries(
    * Fonction utilitaire pour indexer rapidement une seule requête
    * @param queryId Identifiant de la requête à indexer
    * @param queryDetails Détails de la requête à indexer
-   * @param apiBaseUrl URL de base de l'API (par défaut: http://localhost:5599)
+ * @param apiBaseUrl URL de base de l'API (par défaut: http://localhost:3000)
    * @returns Promesse résolue avec le résultat de l'indexation
    */
   export async function indexSingleQuery(
     queryId: string,
     queryDetails: any,
-    apiBaseUrl: string = 'http://localhost:5599'
+    apiBaseUrl: string = 'http://localhost:3000'
   ): Promise<any> {
     try {
       // Préparation des données pour l'API
@@ -194,12 +194,12 @@ export async function indexQueries(
   /**
    * Indexe toutes les requêtes de plusieurs modules en une seule opération
    * @param queryModules Tableau d'objets de requêtes de différents modules
-   * @param apiBaseUrl URL de base de l'API (par défaut: http://localhost:5599)
+ * @param apiBaseUrl URL de base de l'API (par défaut: http://localhost:3000)
    * @returns Promesse résolue avec le résultat de l'indexation
    */
   export async function indexMultipleModules(
     queryModules: Record<string, any>[],
-    apiBaseUrl: string = 'http://localhost:5599'
+    apiBaseUrl: string = 'http://localhost:3000'
   ): Promise<any> {
     try {
       // Fusionner tous les modules en un seul objet de requêtes

--- a/Backend/chatbot_service/src/whatsapp/whatsapp.controller.ts
+++ b/Backend/chatbot_service/src/whatsapp/whatsapp.controller.ts
@@ -83,7 +83,7 @@ export class WhatsappController {
 
             // Appeler le contrôleur analyze/chatbot
             const analyzeResponse = await firstValueFrom(
-              this.httpService.post('http://192.168.20.225:5599/analyze/chatbot', {
+              this.httpService.post('http://192.168.20.225:3000/analyze/chatbot', {
                 question: questionContent
               })
             );

--- a/Frontend/mobile_expo/app/utils/url.ts
+++ b/Frontend/mobile_expo/app/utils/url.ts
@@ -2,7 +2,7 @@ import { Platform } from 'react-native';
 
 export const url = {
     local: 'https://37ff-2a01-cb15-11-6800-a4e-b046-f737-8707.ngrok-free.app/',
-    chatbot: 'http://192.168.20.225:5599/',
+    chatbot: 'http://192.168.20.225:3000/',
     home: 'http://86.200.249.166/',
     email: Platform.OS === 'web' ? 'http://localhost:4444' : 'http://192.168.20.225:4444',
     forwarded: 'https://4dc9-2a01-cb15-11-6800-b2a7-9ce3-5d5-e4af.ngrok-free.app',

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -265,6 +265,8 @@ services:
         condition: service_started
       documents:
         condition: service_started
+      chatbot:
+        condition: service_started
     networks:
       - app-network
     extra_hosts:


### PR DESCRIPTION
## Summary
- proxy chatbot service via the API gateway
- update frontend base URL for chatbot
- adjust WhatsApp service to query gateway
- update Elasticsearch indexer defaults
- depend api-gateway on chatbot container

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68415b626f848324b8b6f0a94b9af836