### PR TITLE
Add Jest tests for documents module

### DIFF
--- a/Backend/api_gateway/test/documents.e2e-spec.ts
+++ b/Backend/api_gateway/test/documents.e2e-spec.ts
@@ -1,0 +1,69 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, HttpStatus } from '@nestjs/common';
+import * as request from 'supertest';
+import { of, throwError } from 'rxjs';
+import { DocumentsModule } from '../src/documents/documents.module';
+
+describe('DocumentsController (e2e)', () => {
+  let app: INestApplication;
+  const documentsService = { send: jest.fn() };
+
+  beforeEach(async () => {
+    const moduleRef: TestingModule = await Test.createTestingModule({
+      imports: [DocumentsModule],
+    })
+      .overrideProvider('DOCUMENTS_SERVICE')
+      .useValue(documentsService)
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+  });
+
+  afterEach(async () => {
+    jest.clearAllMocks();
+    await app.close();
+  });
+
+  it('GET /documents returns documents', async () => {
+    documentsService.send.mockReturnValue(of([{ id: 1 }]));
+    await request(app.getHttpServer())
+      .get('/documents')
+      .query({ projectId: 1 })
+      .expect(HttpStatus.OK)
+      .expect([{ id: 1 }]);
+  });
+
+  it('POST /documents creates a document', async () => {
+    const dto = {
+      project_id: 1,
+      type: 'devis',
+      reference: 'REF',
+      issue_date: new Date().toISOString(),
+    };
+    documentsService.send.mockReturnValue(of({ id: 1, ...dto }));
+    await request(app.getHttpServer())
+      .post('/documents')
+      .send(dto)
+      .expect(HttpStatus.CREATED)
+      .expect({ id: 1, ...dto });
+  });
+
+  it('DELETE /documents/:id returns 200 when found', async () => {
+    documentsService.send.mockReturnValue(of(true));
+    await request(app.getHttpServer())
+      .delete('/documents/1')
+      .expect(HttpStatus.OK)
+      .expect('true');
+  });
+
+  it('DELETE /documents/:id returns 404 when not found', async () => {
+    documentsService.send.mockReturnValue(of(false));
+    await request(app.getHttpServer()).delete('/documents/1').expect(HttpStatus.NOT_FOUND);
+  });
+
+  it('handles service errors', async () => {
+    documentsService.send.mockReturnValue(throwError(() => new Error('fail')));
+    await request(app.getHttpServer()).get('/documents').expect(HttpStatus.INTERNAL_SERVER_ERROR);
+  });
+});

--- a/Backend/documents_service/src/app.service.spec.ts
+++ b/Backend/documents_service/src/app.service.spec.ts
@@ -1,0 +1,93 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AppService } from './app.service';
+import { PrismaService } from './prisma/prisma.service';
+import { DocumentType } from './interfaces/document.interface';
+
+const mockPrisma = {
+  documents: {
+    findMany: jest.fn(),
+    create: jest.fn(),
+    delete: jest.fn(),
+  },
+};
+
+describe('AppService', () => {
+  let service: AppService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [AppService, { provide: PrismaService, useValue: mockPrisma }],
+    }).compile();
+
+    service = module.get<AppService>(AppService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getAllDocuments', () => {
+    it('should return documents filtered by projectId', async () => {
+      mockPrisma.documents.findMany.mockResolvedValue([{ id: 1 }]);
+      const result = await service.getAllDocuments(undefined, undefined, undefined, undefined, 1);
+
+      expect(mockPrisma.documents.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { project_id: 1 },
+        }),
+      );
+      expect(result).toEqual([{ id: 1 }]);
+    });
+
+    it('should throw when prisma fails', async () => {
+      mockPrisma.documents.findMany.mockRejectedValue(new Error('fail'));
+      await expect(service.getAllDocuments()).rejects.toThrow('fail');
+    });
+  });
+
+  describe('createDocument', () => {
+    it('should create a document', async () => {
+      const dto = {
+        project_id: 1,
+        type: DocumentType.DEVIS,
+        reference: 'REF',
+        issue_date: new Date(),
+      };
+      const created = { id: 1, ...dto };
+      mockPrisma.documents.create.mockResolvedValue(created);
+      const result = await service.createDocument(dto as any);
+
+      expect(mockPrisma.documents.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({ ...dto, created_at: expect.any(Date) }),
+      });
+      expect(result).toEqual(created);
+    });
+
+    it('should throw when prisma fails', async () => {
+      const dto = {
+        project_id: 1,
+        type: DocumentType.DEVIS,
+        reference: 'REF',
+        issue_date: new Date(),
+      };
+      mockPrisma.documents.create.mockRejectedValue(new Error('fail'));
+      await expect(service.createDocument(dto as any)).rejects.toThrow('fail');
+    });
+  });
+
+  describe('deleteDocument', () => {
+    it('should return true when deletion succeeds', async () => {
+      mockPrisma.documents.delete.mockResolvedValue({});
+      const result = await service.deleteDocument(1);
+
+      expect(mockPrisma.documents.delete).toHaveBeenCalledWith({ where: { id: 1 } });
+      expect(result).toBe(true);
+    });
+
+    it('should return false when prisma throws', async () => {
+      mockPrisma.documents.delete.mockRejectedValue(new Error('fail'));
+      const result = await service.deleteDocument(1);
+      expect(result).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for AppService (documents service)
- add e2e tests for DocumentsController

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68415e9615808324b92b5fef0b5185c9