### PR TITLE
Implement Chatbot message handler and unit tests

### DIFF
--- a/Backend/chatbot_service/src/analyze_agent/query-executor.service.ts
+++ b/Backend/chatbot_service/src/analyze_agent/query-executor.service.ts
@@ -219,4 +219,14 @@ export class QueryExecutorService {
       this.logger.log('Cache entièrement invalidé');
     }
   }
+
+  /**
+   * Récupère la définition des paramètres pour une requête donnée
+   * @param queryId Identifiant de la requête
+   * @returns La liste des paramètres attendus ou undefined
+   */
+  getParameterDefinitions(queryId: string): QueryParameter[] | undefined {
+    const queryDetails = this.queryMap[queryId];
+    return queryDetails?.parameters;
+  }
 }

--- a/Backend/chatbot_service/src/chatbot/chatbot.module.ts
+++ b/Backend/chatbot_service/src/chatbot/chatbot.module.ts
@@ -2,12 +2,14 @@ import { Module } from '@nestjs/common';
 import { ChatbotController } from './chatbot.controller';
 import { ChatbotService } from './chatbot.service';
 import { AnalyzeAgentModule } from '../analyze_agent/analyze_agent.module';
+import { AnalyzeAgentService } from '../analyze_agent/analyze_agent.service';
 import { QueryCacheService } from './query-cache.service';
 import { LangchainModule } from '../langchain/langchain.module';
 import { ElasticsearchModule } from '../elasticsearch/elasticsearch.module';
 import { PrismaModule } from '../prisma/prisma.module';
 import { EmbeddingModule } from '../embedding/embedding.module';
 import { ConfigModule } from '@nestjs/config';
+import { QueryExecutorService } from '../analyze_agent/query-executor.service';
 
 @Module({
   imports: [
@@ -19,7 +21,12 @@ import { ConfigModule } from '@nestjs/config';
     ConfigModule.forRoot(),
   ],
   controllers: [ChatbotController],
-  providers: [ChatbotService, QueryCacheService],
+  providers: [
+    ChatbotService,
+    QueryCacheService,
+    { provide: 'AnalyzeAgentService', useExisting: AnalyzeAgentService },
+    { provide: 'QueryExecutorService', useExisting: QueryExecutorService },
+  ],
   exports: [ChatbotService, QueryCacheService],
 })
 export class ChatbotModule {}

--- a/Backend/chatbot_service/src/chatbot/chatbot.service.spec.ts
+++ b/Backend/chatbot_service/src/chatbot/chatbot.service.spec.ts
@@ -1,0 +1,117 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ChatbotService } from './chatbot.service';
+import { LangchainService } from '../langchain/langchain.service';
+
+const analyzeAgentServiceMock = {
+  analyzeQuestion: jest.fn(),
+  getConversationContext: jest.fn(),
+  updateConversationContext: jest.fn(),
+};
+
+const queryExecutorServiceMock = {
+  executeQuery: jest.fn(),
+  getParameterDefinitions: jest.fn(),
+};
+
+const langchainServiceMock = {
+  generateResponse: jest.fn(),
+  generateGeneralResponse: jest.fn(),
+  extractParameters: jest.fn(),
+};
+
+describe('ChatbotService', () => {
+  let service: ChatbotService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ChatbotService,
+        { provide: 'AnalyzeAgentService', useValue: analyzeAgentServiceMock },
+        { provide: 'QueryExecutorService', useValue: queryExecutorServiceMock },
+        { provide: LangchainService, useValue: langchainServiceMock },
+      ],
+    }).compile();
+
+    service = module.get<ChatbotService>(ChatbotService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns planning for tomorrow', async () => {
+    analyzeAgentServiceMock.analyzeQuestion.mockResolvedValue({
+      reformulatedQuestion: 'planning du 10/04/2024',
+      analysis: {
+        intent: 'get_planning',
+        entities: [{ name: 'date', value: '2024-04-10', type: 'date' }],
+      },
+      similarPredefinedQueries: [
+        { query_id: 'planning_by_date', description: 'Planning pour une date', score: 0.9 },
+      ],
+    });
+    analyzeAgentServiceMock.getConversationContext.mockReturnValue(undefined);
+    queryExecutorServiceMock.getParameterDefinitions.mockReturnValue([{ name: 'DATE', description: 'date' }]);
+    langchainServiceMock.extractParameters.mockResolvedValue({ DATE: '2024-04-10' });
+    queryExecutorServiceMock.executeQuery.mockResolvedValue({
+      data: [{ task: 'Pose de carrelage' }],
+      description: 'Planning pour une date',
+      response_format: 'json',
+    });
+    langchainServiceMock.generateResponse.mockResolvedValue('Demain: Pose de carrelage.');
+
+    const response = await service.handleUserMessage('u1', 'Quel est le planning de demain ?');
+
+    expect(response).toBe('Demain: Pose de carrelage.');
+    expect(analyzeAgentServiceMock.updateConversationContext).toHaveBeenCalled();
+  });
+
+  it('lists documents of project Dupont', async () => {
+    analyzeAgentServiceMock.analyzeQuestion.mockResolvedValue({
+      reformulatedQuestion: 'documents du projet Dupont',
+      analysis: {
+        intent: 'get_documents',
+        entities: [{ name: 'project', value: 'Dupont', type: 'project' }],
+      },
+      similarPredefinedQueries: [
+        { query_id: 'documents_by_project', description: 'Documents par projet', score: 0.92 },
+      ],
+    });
+    analyzeAgentServiceMock.getConversationContext.mockReturnValue(undefined);
+    queryExecutorServiceMock.getParameterDefinitions.mockReturnValue([{ name: 'PROJECT', description: 'Nom du projet' }]);
+    langchainServiceMock.extractParameters.mockResolvedValue({ PROJECT: 'Dupont' });
+    queryExecutorServiceMock.executeQuery.mockResolvedValue({
+      data: [{ name: 'plan.pdf' }, { name: 'budget.xlsx' }],
+      description: 'Documents par projet',
+      response_format: 'json',
+    });
+    langchainServiceMock.generateResponse.mockResolvedValue('Deux documents trouvés pour le chantier Dupont.');
+
+    const response = await service.handleUserMessage('u1', 'Affiche les documents du chantier Dupont');
+
+    expect(response).toContain('chantier Dupont');
+  });
+
+  it("answers with clients without quote", async () => {
+    analyzeAgentServiceMock.analyzeQuestion.mockResolvedValue({
+      reformulatedQuestion: 'clients sans devis',
+      analysis: { intent: 'list_clients_without_quote', entities: [] },
+      similarPredefinedQueries: [
+        { query_id: 'clients_without_quote', description: 'Clients sans devis', score: 0.95 },
+      ],
+    });
+    analyzeAgentServiceMock.getConversationContext.mockReturnValue(undefined);
+    queryExecutorServiceMock.getParameterDefinitions.mockReturnValue([]);
+    langchainServiceMock.extractParameters.mockResolvedValue({});
+    queryExecutorServiceMock.executeQuery.mockResolvedValue({
+      data: [{ name: 'Client A' }, { name: 'Client B' }],
+      description: 'Clients sans devis',
+      response_format: 'json',
+    });
+    langchainServiceMock.generateResponse.mockResolvedValue('Clients sans devis : Client A, Client B.');
+
+    const response = await service.handleUserMessage('u1', "Quels clients n'ont pas de devis ?");
+
+    expect(response).toMatch(/Client A/);
+  });
+});

--- a/Backend/chatbot_service/src/chatbot/chatbot.service.ts
+++ b/Backend/chatbot_service/src/chatbot/chatbot.service.ts
@@ -1,8 +1,13 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Inject } from '@nestjs/common';
+import { LangchainService } from '../langchain/langchain.service';
 
 @Injectable()
 export class ChatbotService {
-  constructor() {}
+  constructor(
+    @Inject('AnalyzeAgentService') private readonly analyzeAgentService: any,
+    @Inject('QueryExecutorService') private readonly queryExecutorService: any,
+    private readonly langchainService: LangchainService,
+  ) {}
 
   async getHealth(): Promise<{ status: string; database: string; services: string[] }> {
     // Vérification de l'état de la base de données
@@ -18,5 +23,72 @@ export class ChatbotService {
       database: databaseStatus,
       services: servicesStatus,
     };
+  }
+
+  /**
+   * Traite un message utilisateur complet en orchestrant analyse, exécution de requête et génération de réponse
+   * @param userId Identifiant de l'utilisateur ou de la conversation
+   * @param message Message de l'utilisateur
+   * @returns Réponse générée pour l'utilisateur
+   */
+  async handleUserMessage(userId: string, message: string): Promise<string> {
+    // Étape 1 : analyse de la question
+    const analysis = await this.analyzeAgentService.analyzeQuestion(message);
+
+    // Si aucune requête prédéfinie n'est trouvée, générer une réponse générale
+    if (!analysis.similarPredefinedQueries || analysis.similarPredefinedQueries.length === 0) {
+      const generalResponse = await this.langchainService.generateGeneralResponse(message, analysis);
+      this.analyzeAgentService.updateConversationContext(
+        userId,
+        message,
+        generalResponse,
+        analysis.analysis.intent,
+        analysis.analysis.entities,
+      );
+      return generalResponse;
+    }
+
+    // Requête prédéfinie la plus pertinente
+    const topQuery = analysis.similarPredefinedQueries[0];
+
+    // Extraction des paramètres éventuels via LangChain
+    const paramDefs = this.queryExecutorService.getParameterDefinitions(topQuery.query_id) || [];
+    const previousContext = this.analyzeAgentService.getConversationContext(userId)?.lastEntities;
+    const extractedParams = await this.langchainService.extractParameters(
+      message,
+      paramDefs,
+      previousContext,
+    );
+
+    // Exécuter la requête en base
+    const queryResult = await this.queryExecutorService.executeQuery(
+      topQuery.query_id,
+      extractedParams,
+    );
+
+    // Générer la réponse à partir des données
+    const conversationHistory = this.analyzeAgentService.getConversationContext(userId)?.messages;
+    const generatedResponse = await this.langchainService.generateResponse(
+      {
+        originalQuestion: message,
+        reformulatedQuestion: analysis.reformulatedQuestion,
+        intent: analysis.analysis.intent,
+        entities: analysis.analysis.entities,
+        conversationHistory,
+      },
+      queryResult.data,
+    );
+
+    // Mise à jour du contexte de conversation
+    this.analyzeAgentService.updateConversationContext(
+      userId,
+      message,
+      generatedResponse,
+      analysis.analysis.intent,
+      analysis.analysis.entities,
+      topQuery.query_id,
+    );
+
+    return generatedResponse;
   }
 }


### PR DESCRIPTION
## Summary
- implement a user message orchestrator in `ChatbotService`
- expose parameter definitions from `QueryExecutorService`
- provide injection tokens in `ChatbotModule`
- add unit tests for chatbot scenarios

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684162f3b4f88324a36f282572b7b3b9