### PR TITLE
Improve chatbot tests

### DIFF
--- a/Backend/chatbot_service/src/chatbot/chatbot.service.spec.ts
+++ b/Backend/chatbot_service/src/chatbot/chatbot.service.spec.ts
@@ -114,4 +114,26 @@ describe('ChatbotService', () => {
 
     expect(response).toMatch(/Client A/);
   });
+
+  it('returns general answer when no predefined query', async () => {
+    analyzeAgentServiceMock.analyzeQuestion.mockResolvedValue({
+      reformulatedQuestion: 'hello',
+      analysis: { intent: 'smalltalk', entities: [] },
+      similarPredefinedQueries: [],
+    });
+    langchainServiceMock.generateGeneralResponse.mockResolvedValue('Salut!');
+
+    const response = await service.handleUserMessage('u1', 'Bonjour');
+
+    expect(response).toBe('Salut!');
+    expect(langchainServiceMock.generateGeneralResponse).toHaveBeenCalled();
+    expect(analyzeAgentServiceMock.updateConversationContext).toHaveBeenCalled();
+  });
+
+  it('provides health status', async () => {
+    const status = await service.getHealth();
+    expect(status.status).toBe('ok');
+    expect(status.database).toBe('connected');
+    expect(status.services.length).toBeGreaterThan(0);
+  });
 });


### PR DESCRIPTION
## Summary
- extend `chatbot.service.spec` with coverage for general answer and health status

## Testing
- `npx jest --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_6841673ed4888324a9cdd15be0da4497