### PR TITLE
Refactor project controller and add service test

### DIFF
--- a/Backend/api_gateway/src/main.ts
+++ b/Backend/api_gateway/src/main.ts
@@ -1,8 +1,13 @@
 import { NestFactory } from '@nestjs/core';
+import { ValidationPipe } from '@nestjs/common';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  app.useGlobalPipes(
+    new ValidationPipe({ whitelist: true, transform: true }),
+  );
 
   // Configuration globale
   app.setGlobalPrefix('');

--- a/Backend/api_gateway/src/projects/projects.controller.ts
+++ b/Backend/api_gateway/src/projects/projects.controller.ts
@@ -4,13 +4,11 @@ import {
   Delete,
   Get,
   Inject,
-  Injectable,
   Param,
   Post,
   Put,
-  HttpException,
-  HttpStatus,
   Query,
+  ParseIntPipe,
 } from '@nestjs/common';
 import { ClientProxy } from '@nestjs/microservices';
 import {
@@ -32,7 +30,6 @@ import {
 } from '../interfaces/address.interface';
 import { firstValueFrom } from 'rxjs';
 
-@Injectable()
 @Controller('projects')
 export class ProjectsController {
   constructor(
@@ -46,377 +43,240 @@ export class ProjectsController {
     @Query('offset') offset?: number,
     @Query('searchQuery') searchQuery?: string,
   ): Promise<Project[]> {
-    if (!this.projectsService) {
-      throw new HttpException(
-        'Service non disponible',
-        HttpStatus.SERVICE_UNAVAILABLE,
-      );
-    }
-    try {
-      return await firstValueFrom(
-        this.projectsService.send(
-          { cmd: 'get_all_projects' },
-          {
-            limit: limit ? Number(limit) : undefined,
-            offset: offset ? Number(offset) : undefined,
-            searchQuery,
-          },
-        ),
-      );
-    } catch (error) {
-      console.error('Erreur lors de la récupération des projets:', error);
-      throw new HttpException(
-        'Erreur lors de la récupération des projets',
-        HttpStatus.INTERNAL_SERVER_ERROR,
-      );
-    }
+    return firstValueFrom(
+      this.projectsService.send(
+        { cmd: 'get_all_projects' },
+        {
+          limit: limit ? Number(limit) : undefined,
+          offset: offset ? Number(offset) : undefined,
+          searchQuery,
+        },
+      ),
+    );
   }
 
   @Get(':id')
-  async getProjectById(@Param('id') id: string): Promise<Project> {
-    if (!this.projectsService) {
-      throw new HttpException(
-        'Service non disponible',
-        HttpStatus.SERVICE_UNAVAILABLE,
-      );
-    }
-    try {
-      const projectId = Number(id);
-      if (isNaN(projectId)) {
-        throw new HttpException(
-          'ID de projet invalide',
-          HttpStatus.BAD_REQUEST,
-        );
-      }
-      return await firstValueFrom(
-        this.projectsService.send(
-          { cmd: 'get_project_by_id' },
-          { id: projectId },
-        ),
-      );
-    } catch (error) {
-      if (error instanceof HttpException) {
-        throw error;
-      }
-      throw new HttpException(
-        'Erreur lors de la récupération du projet',
-        HttpStatus.INTERNAL_SERVER_ERROR,
-      );
-    }
+  async getProjectById(@Param('id', ParseIntPipe) id: number): Promise<Project> {
+    return firstValueFrom(
+      this.projectsService.send(
+        { cmd: 'get_project_by_id' },
+        { id },
+      ),
+    );
   }
 
   @Post()
   async createProject(
     @Body() createProjectDto: CreateProjectDto,
   ): Promise<Project> {
-    return await firstValueFrom(
+    return firstValueFrom(
       this.projectsService.send({ cmd: 'create_project' }, createProjectDto),
     );
   }
 
   @Put(':id')
   async updateProject(
-    @Param('id') id: number,
+    @Param('id', ParseIntPipe) id: number,
     @Body() updateProjectDto: UpdateProjectDto,
   ): Promise<Project> {
-    return await firstValueFrom(
+    return firstValueFrom(
       this.projectsService.send(
         { cmd: 'update_project' },
-        { id: Number(id), projectDto: updateProjectDto },
+        { id, projectDto: updateProjectDto },
       ),
     );
   }
 
   @Delete(':id')
-  async deleteProject(@Param('id') id: number): Promise<boolean> {
-    return await firstValueFrom(
-      this.projectsService.send({ cmd: 'delete_project' }, { id: Number(id) }),
+  async deleteProject(@Param('id', ParseIntPipe) id: number): Promise<boolean> {
+    return firstValueFrom(
+      this.projectsService.send({ cmd: 'delete_project' }, { id }),
     );
   }
 
   @Get(':id/stages')
-  async getStagesByProjectId(@Param('id') id: number): Promise<Stage[]> {
-    return await firstValueFrom(
+  async getStagesByProjectId(
+    @Param('id', ParseIntPipe) id: number,
+  ): Promise<Stage[]> {
+    return firstValueFrom(
       this.projectsService.send(
         { cmd: 'get_stages_by_project_id' },
-        { projectId: Number(id) },
+        { projectId: id },
       ),
     );
   }
 
   @Post(':id/stages')
   async createStage(
-    @Param('id') id: number,
+    @Param('id', ParseIntPipe) id: number,
     @Body() createStageDto: CreateStageDto,
   ): Promise<Stage> {
-    return await firstValueFrom(
+    return firstValueFrom(
       this.projectsService.send(
         { cmd: 'create_stage' },
-        { projectId: Number(id), stageDto: createStageDto },
+        { projectId: id, stageDto: createStageDto },
       ),
     );
   }
 
   @Put('stages/:id')
   async updateStage(
-    @Param('id') id: number,
+    @Param('id', ParseIntPipe) id: number,
     @Body() updateStageDto: UpdateStageDto,
   ): Promise<Stage> {
-    return await firstValueFrom(
+    return firstValueFrom(
       this.projectsService.send(
         { cmd: 'update_stage' },
-        { id: Number(id), stageDto: updateStageDto },
+        { id, stageDto: updateStageDto },
       ),
     );
   }
 
   @Delete('stages/:id')
-  async deleteStage(@Param('id') id: number): Promise<boolean> {
-    return await firstValueFrom(
-      this.projectsService.send({ cmd: 'delete_stage' }, { id: Number(id) }),
+  async deleteStage(@Param('id', ParseIntPipe) id: number): Promise<boolean> {
+    return firstValueFrom(
+      this.projectsService.send({ cmd: 'delete_stage' }, { id }),
     );
   }
 
   @Get('tags')
   async getAllTags(): Promise<Tag[]> {
-    return await firstValueFrom(
+    return firstValueFrom(
       this.projectsService.send({ cmd: 'get_all_tags' }, {}),
     );
   }
 
   @Post(':id/tags/:tagId')
   async addTagToProject(
-    @Param('id') id: number,
-    @Param('tagId') tagId: number,
+    @Param('id', ParseIntPipe) id: number,
+    @Param('tagId', ParseIntPipe) tagId: number,
   ): Promise<void> {
-    return await firstValueFrom(
+    return firstValueFrom(
       this.projectsService.send(
         { cmd: 'add_tag_to_project' },
-        { projectId: Number(id), tagId: Number(tagId) },
+        { projectId: id, tagId },
       ),
     );
   }
 
   @Delete(':id/tags/:tagId')
   async removeTagFromProject(
-    @Param('id') id: number,
-    @Param('tagId') tagId: number,
+    @Param('id', ParseIntPipe) id: number,
+    @Param('tagId', ParseIntPipe) tagId: number,
   ): Promise<void> {
-    return await firstValueFrom(
+    return firstValueFrom(
       this.projectsService.send(
         { cmd: 'remove_tag_from_project' },
-        { projectId: Number(id), tagId: Number(tagId) },
+        { projectId: id, tagId },
       ),
     );
   }
 
   @Get('client/:clientId')
   async getProjectsByClientId(
-    @Param('clientId') clientId: string,
+    @Param('clientId', ParseIntPipe) clientId: number,
     @Query('limit') limit?: number,
     @Query('offset') offset?: number,
   ): Promise<Project[]> {
-    if (!this.projectsService) {
-      throw new HttpException(
-        'Service non disponible',
-        HttpStatus.SERVICE_UNAVAILABLE,
-      );
-    }
-    try {
-      const parsedClientId = Number(clientId);
-      if (isNaN(parsedClientId)) {
-        throw new HttpException(
-          'ID de client invalide',
-          HttpStatus.BAD_REQUEST,
-        );
-      }
-      return await firstValueFrom(
-        this.projectsService.send(
-          { cmd: 'get_projects_by_client_id' },
-          {
-            clientId: parsedClientId,
-            limit: limit ? Number(limit) : undefined,
-            offset: offset ? Number(offset) : undefined,
-          },
-        ),
-      );
-    } catch (error) {
-      if (error instanceof HttpException) {
-        throw error;
-      }
-      console.error(
-        'Erreur lors de la récupération des projets par client:',
-        error,
-      );
-      throw new HttpException(
-        'Erreur lors de la récupération des projets par client',
-        HttpStatus.INTERNAL_SERVER_ERROR,
-      );
-    }
+    return firstValueFrom(
+      this.projectsService.send(
+        { cmd: 'get_projects_by_client_id' },
+        {
+          clientId,
+          limit: limit ? Number(limit) : undefined,
+          offset: offset ? Number(offset) : undefined,
+        },
+      ),
+    );
   }
 
   @Get(':id/addresses')
-  async getProjectAddresses(@Param('id') id: number): Promise<Address[]> {
-    try {
-      return await firstValueFrom(
-        this.clientsService.send(
-          { cmd: 'get_project_addresses' },
-          { projectId: Number(id) },
-        ),
-      );
-    } catch (error) {
-      console.error(
-        'Erreur lors de la récupération des adresses du projet:',
-        error,
-      );
-      throw new HttpException(
-        'Erreur lors de la récupération des adresses du projet',
-        HttpStatus.INTERNAL_SERVER_ERROR,
-      );
-    }
+  async getProjectAddresses(
+    @Param('id', ParseIntPipe) id: number,
+  ): Promise<Address[]> {
+    return firstValueFrom(
+      this.clientsService.send(
+        { cmd: 'get_project_addresses' },
+        { projectId: id },
+      ),
+    );
   }
 
   @Get(':id/project-addresses')
   async getProjectAddressAssociations(
-    @Param('id') id: number,
+    @Param('id', ParseIntPipe) id: number,
   ): Promise<ProjectAddress[]> {
-    try {
-      return await firstValueFrom(
-        this.clientsService.send(
-          { cmd: 'get_project_addresses' },
-          { projectId: Number(id) },
-        ),
-      );
-    } catch (error) {
-      console.error(
-        'Erreur lors de la récupération des associations projet-adresse:',
-        error,
-      );
-      throw new HttpException(
-        'Erreur lors de la récupération des associations projet-adresse',
-        HttpStatus.INTERNAL_SERVER_ERROR,
-      );
-    }
+    return firstValueFrom(
+      this.clientsService.send(
+        { cmd: 'get_project_addresses' },
+        { projectId: id },
+      ),
+    );
   }
 
   @Get('project-addresses/:id')
   async getProjectAddressById(
-    @Param('id') id: number,
+    @Param('id', ParseIntPipe) id: number,
   ): Promise<ProjectAddress> {
-    try {
-      return await firstValueFrom(
-        this.clientsService.send(
-          { cmd: 'get_project_address_by_id' },
-          { id: Number(id) },
-        ),
-      );
-    } catch (error) {
-      console.error(
-        "Erreur lors de la récupération de l'association projet-adresse:",
-        error,
-      );
-      throw new HttpException(
-        "Erreur lors de la récupération de l'association projet-adresse",
-        HttpStatus.INTERNAL_SERVER_ERROR,
-      );
-    }
+    return firstValueFrom(
+      this.clientsService.send(
+        { cmd: 'get_project_address_by_id' },
+        { id },
+      ),
+    );
   }
 
   @Post(':id/project-addresses')
   async createProjectAddress(
-    @Param('id') id: number,
+    @Param('id', ParseIntPipe) id: number,
     @Body() createProjectAddressDto: CreateProjectAddressDto,
   ): Promise<ProjectAddress> {
-    try {
-      const completeDto = {
-        ...createProjectAddressDto,
-        project_id: Number(id),
-      };
+    const completeDto = {
+      ...createProjectAddressDto,
+      project_id: id,
+    };
 
-      return await firstValueFrom(
-        this.clientsService.send(
-          { cmd: 'create_project_address' },
-          completeDto,
-        ),
-      );
-    } catch (error) {
-      console.error(
-        "Erreur lors de la création de l'association projet-adresse:",
-        error,
-      );
-      throw new HttpException(
-        "Erreur lors de la création de l'association projet-adresse",
-        HttpStatus.INTERNAL_SERVER_ERROR,
-      );
-    }
+    return firstValueFrom(
+      this.clientsService.send(
+        { cmd: 'create_project_address' },
+        completeDto,
+      ),
+    );
   }
 
   @Put('project-addresses/:id')
   async updateProjectAddress(
-    @Param('id') id: number,
+    @Param('id', ParseIntPipe) id: number,
     @Body() updateProjectAddressDto: UpdateProjectAddressDto,
   ): Promise<ProjectAddress> {
-    try {
-      return await firstValueFrom(
-        this.clientsService.send(
-          { cmd: 'update_project_address' },
-          { id: Number(id), projectAddressDto: updateProjectAddressDto },
-        ),
-      );
-    } catch (error) {
-      console.error(
-        "Erreur lors de la mise à jour de l'association projet-adresse:",
-        error,
-      );
-      throw new HttpException(
-        "Erreur lors de la mise à jour de l'association projet-adresse",
-        HttpStatus.INTERNAL_SERVER_ERROR,
-      );
-    }
+    return firstValueFrom(
+      this.clientsService.send(
+        { cmd: 'update_project_address' },
+        { id, projectAddressDto: updateProjectAddressDto },
+      ),
+    );
   }
 
   @Delete('project-addresses/:id')
-  async deleteProjectAddress(@Param('id') id: number): Promise<boolean> {
-    try {
-      return await firstValueFrom(
-        this.clientsService.send(
-          { cmd: 'delete_project_address' },
-          { id: Number(id) },
-        ),
-      );
-    } catch (error) {
-      console.error(
-        "Erreur lors de la suppression de l'association projet-adresse:",
-        error,
-      );
-      throw new HttpException(
-        "Erreur lors de la suppression de l'association projet-adresse",
-        HttpStatus.INTERNAL_SERVER_ERROR,
-      );
-    }
+  async deleteProjectAddress(@Param('id', ParseIntPipe) id: number): Promise<boolean> {
+    return firstValueFrom(
+      this.clientsService.send(
+        { cmd: 'delete_project_address' },
+        { id },
+      ),
+    );
   }
 
   @Put(':projectId/project-addresses/:addressId/set-default')
   async setDefaultProjectAddress(
-    @Param('projectId') projectId: number,
-    @Param('addressId') addressId: number,
+    @Param('projectId', ParseIntPipe) projectId: number,
+    @Param('addressId', ParseIntPipe) addressId: number,
   ): Promise<boolean> {
-    try {
-      return await firstValueFrom(
-        this.clientsService.send(
-          { cmd: 'set_default_project_address' },
-          { projectId: Number(projectId), addressId: Number(addressId) },
-        ),
-      );
-    } catch (error) {
-      console.error(
-        "Erreur lors de la définition de l'adresse par défaut du projet:",
-        error,
-      );
-      throw new HttpException(
-        "Erreur lors de la définition de l'adresse par défaut du projet",
-        HttpStatus.INTERNAL_SERVER_ERROR,
-      );
-    }
+    return firstValueFrom(
+      this.clientsService.send(
+        { cmd: 'set_default_project_address' },
+        { projectId, addressId },
+      ),
+    );
   }
 }

--- a/Backend/projects_service/src/projects/projects.service.spec.ts
+++ b/Backend/projects_service/src/projects/projects.service.spec.ts
@@ -1,0 +1,34 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ProjectsService } from './projects.service';
+import { PrismaService } from '../prisma/prisma.service';
+
+describe('ProjectsService', () => {
+  let service: ProjectsService;
+  const prisma = {
+    projects: { create: jest.fn(), update: jest.fn() },
+    $transaction: jest.fn(),
+  } as any;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ProjectsService, { provide: PrismaService, useValue: prisma }],
+    }).compile();
+
+    service = module.get<ProjectsService>(ProjectsService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should create project with generated reference when none provided', async () => {
+    prisma.$transaction.mockImplementation(async (cb: any) => cb(prisma));
+    prisma.projects.create.mockResolvedValue({ id: 1 });
+    prisma.projects.update.mockResolvedValue({ id: 1, reference: 'PRJ - 1' });
+
+    const result = await service.createProject({ name: 'Test', clientId: 2 });
+
+    expect(prisma.$transaction).toHaveBeenCalled();
+    expect(result.reference).toBe('PRJ - 1');
+  });
+});


### PR DESCRIPTION
## Summary
- simplify `ProjectsController` with `ParseIntPipe` and remove redundant error handling
- enable global validation pipe in the gateway
- add unit test for `ProjectsService`

## Testing
- `npx tsc -p Backend/api_gateway/tsconfig.json --noEmit` *(fails: Cannot find modules)*
- `npm test --prefix Backend/projects_service` *(fails: jest not found)*
- `npm test --prefix Backend/api_gateway` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684165e9186c83248268a205254478da