### PR TITLE
Add basic Swagger docs

### DIFF
--- a/Backend/api_gateway/src/clients/clients.controller.ts
+++ b/Backend/api_gateway/src/clients/clients.controller.ts
@@ -9,6 +9,16 @@ import {
   Put,
   Query,
 } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiQuery,
+  ApiParam,
+  ApiBody,
+  ApiOkResponse,
+  ApiCreatedResponse,
+  ApiNoContentResponse,
+} from '@nestjs/swagger';
 import { ClientProxy } from '@nestjs/microservices';
 import {
   Client,
@@ -26,6 +36,7 @@ import {
 } from '../interfaces/address.interface';
 import { firstValueFrom } from 'rxjs';
 
+@ApiTags('clients')
 @Controller('clients')
 export class ClientsController {
   constructor(
@@ -33,6 +44,15 @@ export class ClientsController {
   ) {}
 
   @Get()
+  @ApiOperation({ summary: 'Liste des clients' })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiQuery({ name: 'offset', required: false, type: Number })
+  @ApiQuery({ name: 'searchQuery', required: false, type: String })
+  @ApiQuery({ name: 'typeFilter', required: false, type: String })
+  @ApiQuery({ name: 'cityFilter', required: false, type: String })
+  @ApiQuery({ name: 'statusFilter', required: false, type: String })
+  @ApiQuery({ name: 'lastOrderFilter', required: false, type: String })
+  @ApiOkResponse({ description: 'Liste de clients' })
   async getAllClients(
     @Query('limit') limit?: number,
     @Query('offset') offset?: number,
@@ -59,6 +79,9 @@ export class ClientsController {
   }
 
   @Get(':id')
+  @ApiOperation({ summary: 'R\u00e9cup\u00e9rer un client par son identifiant' })
+  @ApiParam({ name: 'id', type: Number })
+  @ApiOkResponse({ description: 'Client trouv\u00e9' })
   async getClientById(@Param('id') id: number): Promise<Client> {
     return await firstValueFrom(
       this.clientsService.send({ cmd: 'get_client_by_id' }, { id: Number(id) }),
@@ -66,6 +89,9 @@ export class ClientsController {
   }
 
   @Post()
+  @ApiOperation({ summary: 'Cr\u00e9er un client' })
+  @ApiBody({ type: CreateClientDto })
+  @ApiCreatedResponse({ description: 'Client cr\u00e9\u00e9' })
   async createClient(
     @Body() createClientDto: CreateClientDto,
   ): Promise<Client> {
@@ -75,6 +101,10 @@ export class ClientsController {
   }
 
   @Put(':id')
+  @ApiOperation({ summary: 'Mettre \u00e0 jour un client' })
+  @ApiParam({ name: 'id', type: Number })
+  @ApiBody({ type: UpdateClientDto })
+  @ApiOkResponse({ description: 'Client mis \u00e0 jour' })
   async updateClient(
     @Param('id') id: number,
     @Body() updateClientDto: UpdateClientDto,
@@ -88,6 +118,9 @@ export class ClientsController {
   }
 
   @Delete(':id')
+  @ApiOperation({ summary: 'Supprimer un client' })
+  @ApiParam({ name: 'id', type: Number })
+  @ApiNoContentResponse({ description: 'Client supprim\u00e9' })
   async deleteClient(@Param('id') id: number): Promise<boolean> {
     return await firstValueFrom(
       this.clientsService.send({ cmd: 'delete_client' }, { id: Number(id) }),
@@ -95,6 +128,9 @@ export class ClientsController {
   }
 
   @Get(':id/addresses')
+  @ApiOperation({ summary: 'Adresses d\'un client' })
+  @ApiParam({ name: 'id', type: Number })
+  @ApiOkResponse({ description: 'Liste des adresses' })
   async getAddressesByClientId(@Param('id') id: number): Promise<Address[]> {
     return await firstValueFrom(
       this.clientsService.send(
@@ -105,6 +141,10 @@ export class ClientsController {
   }
 
   @Post(':id/addresses')
+  @ApiOperation({ summary: 'Ajouter une adresse \u00e0 un client' })
+  @ApiParam({ name: 'id', type: Number })
+  @ApiBody({ type: CreateAddressDto })
+  @ApiCreatedResponse({ description: 'Adresse cr\u00e9\u00e9e' })
   async createAddress(
     @Param('id') id: number,
     @Body() createAddressDto: CreateAddressDto,
@@ -118,6 +158,10 @@ export class ClientsController {
   }
 
   @Put('addresses/:id')
+  @ApiOperation({ summary: 'Mettre \u00e0 jour une adresse' })
+  @ApiParam({ name: 'id', type: Number })
+  @ApiBody({ type: UpdateAddressDto })
+  @ApiOkResponse({ description: 'Adresse mise \u00e0 jour' })
   async updateAddress(
     @Param('id') id: number,
     @Body() updateAddressDto: UpdateAddressDto,
@@ -131,6 +175,9 @@ export class ClientsController {
   }
 
   @Delete('addresses/:id')
+  @ApiOperation({ summary: 'Supprimer une adresse' })
+  @ApiParam({ name: 'id', type: Number })
+  @ApiNoContentResponse({ description: 'Adresse supprim\u00e9e' })
   async deleteAddress(@Param('id') id: number): Promise<boolean> {
     return await firstValueFrom(
       this.clientsService.send({ cmd: 'delete_address' }, { id: Number(id) }),
@@ -138,6 +185,9 @@ export class ClientsController {
   }
 
   @Get(':id/client-addresses')
+  @ApiOperation({ summary: 'Associations adresse/client' })
+  @ApiParam({ name: 'id', type: Number })
+  @ApiOkResponse({ description: 'Liste des associations' })
   async getClientAddresses(@Param('id') id: number): Promise<ClientAddress[]> {
     return await firstValueFrom(
       this.clientsService.send(
@@ -148,6 +198,9 @@ export class ClientsController {
   }
 
   @Get('client-addresses/:id')
+  @ApiOperation({ summary: 'D\u00e9tail d\'une association adresse/client' })
+  @ApiParam({ name: 'id', type: Number })
+  @ApiOkResponse({ description: 'D\u00e9tails de l\'association' })
   async getClientAddressById(@Param('id') id: number): Promise<ClientAddress> {
     return await firstValueFrom(
       this.clientsService.send(
@@ -158,6 +211,10 @@ export class ClientsController {
   }
 
   @Post(':id/client-addresses')
+  @ApiOperation({ summary: 'Cr\u00e9er une association adresse/client' })
+  @ApiParam({ name: 'id', type: Number })
+  @ApiBody({ type: CreateClientAddressDto })
+  @ApiCreatedResponse({ description: 'Association cr\u00e9\u00e9e' })
   async createClientAddress(
     @Param('id') id: number,
     @Body() createClientAddressDto: CreateClientAddressDto,
@@ -173,6 +230,10 @@ export class ClientsController {
   }
 
   @Put('client-addresses/:id')
+  @ApiOperation({ summary: 'Mettre \u00e0 jour une association' })
+  @ApiParam({ name: 'id', type: Number })
+  @ApiBody({ type: UpdateClientAddressDto })
+  @ApiOkResponse({ description: 'Association mise \u00e0 jour' })
   async updateClientAddress(
     @Param('id') id: number,
     @Body() updateClientAddressDto: UpdateClientAddressDto,
@@ -186,6 +247,9 @@ export class ClientsController {
   }
 
   @Delete('client-addresses/:id')
+  @ApiOperation({ summary: 'Supprimer une association adresse/client' })
+  @ApiParam({ name: 'id', type: Number })
+  @ApiNoContentResponse({ description: 'Association supprim\u00e9e' })
   async deleteClientAddress(@Param('id') id: number): Promise<boolean> {
     return await firstValueFrom(
       this.clientsService.send(
@@ -196,6 +260,10 @@ export class ClientsController {
   }
 
   @Put(':clientId/client-addresses/:addressId/set-default')
+  @ApiOperation({ summary: 'D\u00e9finir l\'adresse par d\u00e9faut' })
+  @ApiParam({ name: 'clientId', type: Number })
+  @ApiParam({ name: 'addressId', type: Number })
+  @ApiOkResponse({ description: 'Association mise \u00e0 jour' })
   async setDefaultClientAddress(
     @Param('clientId') clientId: number,
     @Param('addressId') addressId: number,
@@ -209,6 +277,9 @@ export class ClientsController {
   }
 
   @Get('geocode')
+  @ApiOperation({ summary: 'G\u00e9ocoder une adresse' })
+  @ApiQuery({ name: 'address', type: String })
+  @ApiOkResponse({ description: 'Coordonn\u00e9es g\u00e9ographiques' })
   async geocodeAddress(@Query('address') address: string) {
     return await firstValueFrom(
       this.clientsService.send({ cmd: 'geocode_address' }, { address }),
@@ -216,6 +287,9 @@ export class ClientsController {
   }
 
   @Put('addresses/:id/geocode')
+  @ApiOperation({ summary: 'Mettre \u00e0 jour la g\u00e9olocalisation' })
+  @ApiParam({ name: 'id', type: Number })
+  @ApiOkResponse({ description: 'G\u00e9olocalisation mise \u00e0 jour' })
   async updateAddressCoordinates(@Param('id') id: number) {
     return await firstValueFrom(
       this.clientsService.send(
@@ -226,6 +300,8 @@ export class ClientsController {
   }
 
   @Post('addresses/geocode-all')
+  @ApiOperation({ summary: 'G\u00e9ocoder toutes les adresses' })
+  @ApiOkResponse({ description: 'Op\u00e9ration lanc\u00e9e' })
   async updateAllAddressesCoordinates() {
     return await firstValueFrom(
       this.clientsService.send({ cmd: 'update_all_addresses_coordinates' }, {}),
@@ -233,6 +309,9 @@ export class ClientsController {
   }
 
   @Post('with-address')
+  @ApiOperation({ summary: 'Cr\u00e9er un client avec adresse' })
+  @ApiBody({ type: CreateClientWithAddressDto })
+  @ApiCreatedResponse({ description: 'Client cr\u00e9\u00e9 avec adresse' })
   async createClientWithAddress(
     @Body() createClientWithAddressDto: CreateClientWithAddressDto,
   ): Promise<Client> {

--- a/Backend/api_gateway/src/documents/documents.controller.ts
+++ b/Backend/api_gateway/src/documents/documents.controller.ts
@@ -14,6 +14,16 @@ import {
 } from '@nestjs/common';
 import { ClientProxy } from '@nestjs/microservices';
 import {
+  ApiTags,
+  ApiOperation,
+  ApiQuery,
+  ApiParam,
+  ApiBody,
+  ApiOkResponse,
+  ApiCreatedResponse,
+  ApiNoContentResponse,
+} from '@nestjs/swagger';
+import {
   Document,
   CreateDocumentDto,
   UpdateDocumentDto,
@@ -57,6 +67,7 @@ interface UpdateProjectMediaDto {
 }
 
 @Injectable()
+@ApiTags('documents')
 @Controller('documents')
 export class DocumentsController {
   constructor(
@@ -64,6 +75,13 @@ export class DocumentsController {
   ) {}
 
   @Get()
+  @ApiOperation({ summary: 'Liste des documents' })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiQuery({ name: 'offset', required: false, type: Number })
+  @ApiQuery({ name: 'searchQuery', required: false, type: String })
+  @ApiQuery({ name: 'clientId', required: false, type: Number })
+  @ApiQuery({ name: 'projectId', required: false, type: Number })
+  @ApiOkResponse({ description: 'Liste des documents' })
   async getAllDocuments(
     @Query('limit') limit?: number,
     @Query('offset') offset?: number,
@@ -88,6 +106,9 @@ export class DocumentsController {
   }
 
   @Get('client/:clientId')
+  @ApiOperation({ summary: 'Documents par client' })
+  @ApiParam({ name: 'clientId', type: Number })
+  @ApiOkResponse({ description: 'Liste des documents' })
   async getDocumentsByClientId(
     @Param('clientId') clientId: string,
   ): Promise<Document[]> {
@@ -116,6 +137,9 @@ export class DocumentsController {
   }
 
   @Get('project/:projectId')
+  @ApiOperation({ summary: 'Documents par projet' })
+  @ApiParam({ name: 'projectId', type: Number })
+  @ApiOkResponse({ description: 'Liste des documents' })
   async getDocumentsByProjectId(
     @Param('projectId') projectId: number,
   ): Promise<Document[]> {
@@ -139,6 +163,11 @@ export class DocumentsController {
   }
 
   @Get('media')
+  @ApiOperation({ summary: 'Liste des medias' })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiQuery({ name: 'offset', required: false, type: Number })
+  @ApiQuery({ name: 'projectId', required: false, type: Number })
+  @ApiOkResponse({ description: 'Liste des medias' })
   async getAllProjectMedia(
     @Query('limit') limit?: number,
     @Query('offset') offset?: number,
@@ -161,6 +190,9 @@ export class DocumentsController {
   }
 
   @Get('media/:id')
+  @ApiOperation({ summary: 'M\u00e9dia par id' })
+  @ApiParam({ name: 'id', type: Number })
+  @ApiOkResponse({ description: 'D\u00e9tails du m\u00e9dia' })
   async getProjectMediaById(@Param('id') id: number): Promise<ProjectMedia> {
     try {
       const media = await firstValueFrom(
@@ -181,6 +213,9 @@ export class DocumentsController {
   }
 
   @Get('project/:projectId/media')
+  @ApiOperation({ summary: 'M\u00e9dias par projet' })
+  @ApiParam({ name: 'projectId', type: Number })
+  @ApiOkResponse({ description: 'Liste des medias' })
   async getMediaByProjectId(
     @Param('projectId') projectId: number,
   ): Promise<ProjectMedia[]> {

--- a/Backend/api_gateway/src/interfaces/client.interface.ts
+++ b/Backend/api_gateway/src/interfaces/client.interface.ts
@@ -1,3 +1,5 @@
+import { ApiProperty } from '@nestjs/swagger';
+
 export interface Client {
   id?: number;
   company_name?: string;
@@ -13,39 +15,90 @@ export interface Client {
   updated_at?: Date;
 }
 
-export interface CreateClientDto {
+export class CreateClientDto {
+  @ApiProperty({ required: false, description: "Nom de la soci\u00e9t\u00e9" })
   company_name?: string;
+
+  @ApiProperty({ description: "Pr\u00e9nom du client" })
   firstname: string;
+
+  @ApiProperty({ description: "Nom du client" })
   lastname: string;
+
+  @ApiProperty({ description: "Adresse email" })
   email: string;
+
+  @ApiProperty({ required: false, description: "T\u00e9l\u00e9phone" })
   phone?: string;
+
+  @ApiProperty({ required: false, description: "Mobile" })
   mobile?: string;
+
+  @ApiProperty({ required: false, description: "Identifiant d'adresse" })
   address_id?: number;
+
+  @ApiProperty({ required: false, description: "SIRET" })
   siret?: string;
+
+  @ApiProperty({ required: false, description: "Notes diverses" })
   notes?: string;
 }
 
-export interface UpdateClientDto {
+export class UpdateClientDto {
+  @ApiProperty({ required: false, description: "Nom de la soci\u00e9t\u00e9" })
   company_name?: string;
+
+  @ApiProperty({ required: false, description: "Pr\u00e9nom du client" })
   firstname?: string;
+
+  @ApiProperty({ required: false, description: "Nom du client" })
   lastname?: string;
+
+  @ApiProperty({ required: false, description: "Adresse email" })
   email?: string;
+
+  @ApiProperty({ required: false, description: "T\u00e9l\u00e9phone" })
   phone?: string;
+
+  @ApiProperty({ required: false, description: "Mobile" })
   mobile?: string;
+
+  @ApiProperty({ required: false, description: "Identifiant d'adresse" })
   address_id?: number;
+
+  @ApiProperty({ required: false, description: "SIRET" })
   siret?: string;
+
+  @ApiProperty({ required: false, description: "Notes diverses" })
   notes?: string;
 }
 
-export interface CreateClientWithAddressDto {
+export class CreateClientWithAddressDto {
+  @ApiProperty({ required: false, description: "Nom de la soci\u00e9t\u00e9" })
   company_name?: string;
+
+  @ApiProperty({ required: false, description: "Pr\u00e9nom" })
   firstname?: string;
+
+  @ApiProperty({ required: false, description: "Nom" })
   lastname?: string;
+
+  @ApiProperty({ description: "Email" })
   email: string;
+
+  @ApiProperty({ required: false, description: "T\u00e9l\u00e9phone" })
   phone?: string;
+
+  @ApiProperty({ required: false, description: "Mobile" })
   mobile?: string;
+
+  @ApiProperty({ required: false, description: "SIRET" })
   siret?: string;
+
+  @ApiProperty({ required: false, description: "Notes" })
   notes?: string;
+
+  @ApiProperty({ description: "Adresse" })
   address: {
     street_number: string;
     street_name: string;

--- a/Backend/api_gateway/src/main.ts
+++ b/Backend/api_gateway/src/main.ts
@@ -1,5 +1,6 @@
 import { NestFactory } from '@nestjs/core';
 import { ValidationPipe } from '@nestjs/common';
+import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
@@ -18,6 +19,14 @@ async function bootstrap() {
     methods: 'GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS',
     credentials: true,
   });
+
+  const config = new DocumentBuilder()
+    .setTitle('API Gateway')
+    .setDescription('Documentation des services de l\'API Gateway')
+    .setVersion('1.0')
+    .build();
+  const document = SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup('api', app, document);
 
   // Démarrer l'application
   await app.listen(process.env.PORT ?? 3000);

--- a/Backend/api_gateway/src/projects/projects.controller.ts
+++ b/Backend/api_gateway/src/projects/projects.controller.ts
@@ -12,6 +12,16 @@ import {
 } from '@nestjs/common';
 import { ClientProxy } from '@nestjs/microservices';
 import {
+  ApiTags,
+  ApiOperation,
+  ApiQuery,
+  ApiParam,
+  ApiBody,
+  ApiOkResponse,
+  ApiCreatedResponse,
+  ApiNoContentResponse,
+} from '@nestjs/swagger';
+import {
   Project,
   CreateProjectDto,
   UpdateProjectDto,
@@ -30,6 +40,7 @@ import {
 } from '../interfaces/address.interface';
 import { firstValueFrom } from 'rxjs';
 
+@ApiTags('projects')
 @Controller('projects')
 export class ProjectsController {
   constructor(
@@ -38,6 +49,11 @@ export class ProjectsController {
   ) {}
 
   @Get()
+  @ApiOperation({ summary: 'Liste des projets' })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiQuery({ name: 'offset', required: false, type: Number })
+  @ApiQuery({ name: 'searchQuery', required: false, type: String })
+  @ApiOkResponse({ description: 'Liste des projets' })
   async getAllProjects(
     @Query('limit') limit?: number,
     @Query('offset') offset?: number,
@@ -56,6 +72,9 @@ export class ProjectsController {
   }
 
   @Get(':id')
+  @ApiOperation({ summary: 'D\u00e9tails d\'un projet' })
+  @ApiParam({ name: 'id', type: Number })
+  @ApiOkResponse({ description: 'Projet trouv\u00e9' })
   async getProjectById(@Param('id', ParseIntPipe) id: number): Promise<Project> {
     return firstValueFrom(
       this.projectsService.send(
@@ -66,6 +85,9 @@ export class ProjectsController {
   }
 
   @Post()
+  @ApiOperation({ summary: 'Cr\u00e9er un projet' })
+  @ApiBody({ type: CreateProjectDto })
+  @ApiCreatedResponse({ description: 'Projet cr\u00e9\u00e9' })
   async createProject(
     @Body() createProjectDto: CreateProjectDto,
   ): Promise<Project> {
@@ -75,6 +97,10 @@ export class ProjectsController {
   }
 
   @Put(':id')
+  @ApiOperation({ summary: 'Mettre \u00e0 jour un projet' })
+  @ApiParam({ name: 'id', type: Number })
+  @ApiBody({ type: UpdateProjectDto })
+  @ApiOkResponse({ description: 'Projet mis \u00e0 jour' })
   async updateProject(
     @Param('id', ParseIntPipe) id: number,
     @Body() updateProjectDto: UpdateProjectDto,
@@ -88,6 +114,9 @@ export class ProjectsController {
   }
 
   @Delete(':id')
+  @ApiOperation({ summary: 'Supprimer un projet' })
+  @ApiParam({ name: 'id', type: Number })
+  @ApiNoContentResponse({ description: 'Projet supprim\u00e9' })
   async deleteProject(@Param('id', ParseIntPipe) id: number): Promise<boolean> {
     return firstValueFrom(
       this.projectsService.send({ cmd: 'delete_project' }, { id }),


### PR DESCRIPTION
## Summary
- configure Swagger in API gateway main entry
- document client endpoints
- add Swagger decorators to projects and documents controllers
- annotate client DTOs with ApiProperty

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841689384bc832480df2d69c19a76cd