### PR TITLE
Add missing Prisma runtime dependencies

### DIFF
--- a/Backend/clients_service/package.json
+++ b/Backend/clients_service/package.json
@@ -23,7 +23,8 @@
     "@nestjs/common": "^11.0.1",
     "@nestjs/core": "^11.0.1",
     "@nestjs/microservices": "^11.0.14",
-    "@nestjs/platform-express": "^11.0.1"
+    "@nestjs/platform-express": "^11.0.1",
+    "@prisma/client": "^6.8.2"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/Backend/projects_service/package.json
+++ b/Backend/projects_service/package.json
@@ -23,6 +23,7 @@
     "@nestjs/common": "^11.0.1",
     "@nestjs/core": "^11.0.1",
     "@nestjs/microservices": "^11.0.14",
+    "@prisma/client": "^6.8.2"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/Backend/resources_service/package.json
+++ b/Backend/resources_service/package.json
@@ -24,6 +24,7 @@
     "@nestjs/core": "^11.0.1",
     "@nestjs/microservices": "^11.0.14",
     "@nestjs/swagger": "^11.1.1",
+    "@prisma/client": "^6.8.2"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/Backend/sync_service/package.json
+++ b/Backend/sync_service/package.json
@@ -26,6 +26,7 @@
     "dotenv": "^16.5.0",
     "mssql": "^11.0.1",
     "pg": "^8.14.1",
+    "@prisma/client": "^6.8.2"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",


### PR DESCRIPTION
## Summary
- add `@prisma/client` to package.json files for services using Prisma

## Testing
- `npm install` in `Backend/clients_service`
- `npm install` in `Backend/projects_service`
- `npm install` in `Backend/resources_service`
- `npm install` in `Backend/sync_service`


------
https://chatgpt.com/codex/tasks/task_e_68416a1b865883248eb14187f294b515