### PR TITLE
Fix JSON parsing and e2e spec

### DIFF
--- a/Backend/chatbot_service/test/app.e2e-spec.ts
+++ b/Backend/chatbot_service/test/app.e2e-spec.ts
@@ -1,11 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
-import { App } from 'supertest/types';
 import { AppModule } from './../src/app.module';
 
 describe('AppController (e2e)', () => {
-  let app: INestApplication<App>;
+  let app: INestApplication;
 
   beforeEach(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({

--- a/Backend/documents_service/package.json
+++ b/Backend/documents_service/package.json
@@ -26,7 +26,7 @@
     "@prisma/client": "^6.8.2",
     "@sendgrid/mail": "^8.1.5",
     "@types/pdfkit": "^0.13.9",
-    "pdfkit": "^0.17.0",
+    "pdfkit": "^0.17.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/Backend/projects_service/package.json
+++ b/Backend/projects_service/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@nestjs/common": "^11.0.1",
     "@nestjs/core": "^11.0.1",
-    "@nestjs/microservices": "^11.0.14",
+    "@nestjs/microservices": "^11.0.14"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/Backend/resources_service/package.json
+++ b/Backend/resources_service/package.json
@@ -23,7 +23,7 @@
     "@nestjs/common": "^11.0.1",
     "@nestjs/core": "^11.0.1",
     "@nestjs/microservices": "^11.0.14",
-    "@nestjs/swagger": "^11.1.1",
+    "@nestjs/swagger": "^11.1.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/Backend/sync_service/package.json
+++ b/Backend/sync_service/package.json
@@ -25,7 +25,7 @@
     "@nestjs/swagger": "^11.1.4",
     "dotenv": "^16.5.0",
     "mssql": "^11.0.1",
-    "pg": "^8.14.1",
+    "pg": "^8.14.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",


### PR DESCRIPTION
## Summary
- remove trailing commas in several package.json files so `npm install` works
- fix Chatbot e2e spec import

## Testing
- `npm test` in `Backend/chatbot_service`
- `npm run test:e2e` in `Backend/chatbot_service` *(fails: clientsWhereInput not exported)*
- `npm test` in `Backend/projects_service` *(fails to compile)*

------
https://chatgpt.com/codex/tasks/task_e_68416accfccc83249d4f2b148a4dc801