### PR TITLE
Add Jest and Artillery commands to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 #  Makefile docker compose + Swarm
 ############################################
 
-.PHONY: up down prismaUp
+.PHONY: up down prismaUp test test-watch test-e2e test-cov test-load test-load-report
 
 up:
 	@echo "Lancement de l'application en utilisant docker compose..."
@@ -50,3 +50,24 @@ else
 	bash updatePrisma.sh
 endif
 	@echo "Mise a jour Prisma terminee."
+
+# Jest tests
+test:
+	npm run test
+
+test-watch:
+	npm run test:watch
+
+test-e2e:
+	npm run test:e2e
+
+test-cov:
+	npm run test:cov
+
+# Artillery load tests
+test-load:
+	npx artillery run artillery.yaml
+
+test-load-report:
+	npx artillery run artillery.yaml --output report.json
+	npx artillery report --output report.html report.json


### PR DESCRIPTION
## Summary
- extend the root Makefile with commands to run Jest tests
- add load test commands using Artillery

## Testing
- `make test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68416f66af80832493b91b79836be829