### PR TITLE
Add Artillery load test config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,3 +50,8 @@ else
 	bash updatePrisma.sh
 endif
 	@echo "Mise a jour Prisma terminee."
+
+test-load:
+	@echo "Running Artillery load test..."
+	npx artillery run artillery.yaml --output load-report.json && npx artillery report --output load-report.html load-report.json
+

--- a/README.md
+++ b/README.md
@@ -24,3 +24,15 @@ docker-compose up --build
 ```
 
 This will start PostgreSQL, Elasticsearch and all microservices.
+
+## Load testing
+
+A sample Artillery configuration (`artillery.yaml`) is provided at the repository root.
+Run a quick load test and generate a report with:
+
+```bash
+make test-load
+```
+
+Results will be saved in `load-report.json` and `load-report.html`.
+

--- a/artillery.yaml
+++ b/artillery.yaml
@@ -1,0 +1,59 @@
+config:
+  target: "http://localhost:3000"
+  phases:
+    - duration: 30
+      arrivalRate: 10
+      name: "Warm up"
+    - duration: 30
+      arrivalRate: 50
+      name: "Ramp up"
+    - duration: 30
+      arrivalRate: 100
+      name: "Stress"
+  defaults:
+    headers:
+      Content-Type: application/json
+scenarios:
+  - name: "get-projects"
+    description: "Récupération de la liste des projets"
+    flow:
+      - get:
+          url: "/projects"
+  - name: "create-client"
+    description: "Création d'un client"
+    flow:
+      - post:
+          url: "/clients"
+          json:
+            name: "Client {{ uuid() }}"
+          capture:
+            json: "$.id"
+            as: "clientId"
+  - name: "add-document"
+    description: "Ajout d'un document"
+    flow:
+      - get:
+          url: "/projects"
+          capture:
+            json: "$[0].id"
+            as: "projectId"
+      - post:
+          url: "/documents"
+          json:
+            title: "Document {{ uuid() }}"
+            projectId: "{{ projectId }}"
+          capture:
+            json: "$.id"
+            as: "docId"
+  - name: "delete-document"
+    description: "Création puis suppression d'un document"
+    flow:
+      - post:
+          url: "/documents"
+          json:
+            title: "Temp Doc {{ uuid() }}"
+          capture:
+            json: "$.id"
+            as: "tempDocId"
+      - delete:
+          url: "/documents/{{ tempDocId }}"


### PR DESCRIPTION
## Summary
- add an `artillery.yaml` configuration with four scenarios
- add `test-load` rule in Makefile to run the Artillery test
- document load testing in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68416f0351808324812c77462ff76343